### PR TITLE
Undo remove of initialTheme prop

### DIFF
--- a/src/components/ThemeCustomizer/ThemeCustomizer.tsx
+++ b/src/components/ThemeCustomizer/ThemeCustomizer.tsx
@@ -83,6 +83,7 @@ export const ThemeCustomizer = () => {
         </svg>
       </button>
       <Wrapper
+        initialTheme={{ ...defaultTheme, theme: "contrastTheme" }}
         hasAll={false}
         hidden={hidden}
         onUpdate={(theme) => {


### PR DESCRIPTION
Przywracam usunięty prop `initialTheme`. Nie miałem najnowszej wersji paczek i ts krzyczał że nie jest dopuszczalny 