### PR TITLE
fix: Workflow node version upgrade

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         #node-version: [10.x, 12.x, 14.x, 15.x]
-        node-version: [14.x]
+        node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Due to [github actions node version migration.](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12)

THIS PR IS WAITING FOR [THIS PR](https://github.com/EscolaLMS/Components/pull/277)