### PR TITLE
Fix build error.

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -4,6 +4,15 @@ const { override, useBabelRc } = require("customize-cra");
 
 const aliasMap = configPaths("./tsconfig.paths.json"); // or jsconfig.paths.json
 
-module.exports = override(alias(aliasMap), useBabelRc());
+const supportMjs = () => (webpackConfig) => {
+  webpackConfig.module.rules.push({
+    test: /\.mjs$/,
+    include: /node_modules/,
+    type: "javascript/auto",
+  });
+  return webpackConfig;
+};
+
+module.exports = override(alias(aliasMap), useBabelRc(), supportMjs());
 
 module.exports.jest = aliasJest(aliasMap);


### PR DESCRIPTION
Fix build error.
./node_modules/@radix-ui/react-tooltip/dist/index.mjs
Can't import the named export 'Anchor' from non EcmaScript module (only default export is available)